### PR TITLE
Implementation of energy balance option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
+option (USE_VDB "Use OpenVDB part of the code" ON)
+message(STATUS "Use of OpenVDB: ${USE_VDB}")
+
 enable_testing()
 
 # Custom target to clean CMake cache (like make clean for cache)
@@ -20,8 +23,6 @@ add_custom_target(clean-cache
 
 add_subdirectory(src)
 add_subdirectory(tests)
-
-option (USE_VDB "Use OpenVDB part of the code" ON)
 
 #### Download header files from external Github repos ####
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This is a non-exhaustive list of parameters and options (of the `Simulation` cla
 | `use_musl`        | false | Use MUSL instead of USL
 | `use_mibf`        | false | Use Material-Induced Boundary Friction (MIBF), only relevant for certain plasticity models
 | `pbc`             | false | Use periodic boundary conditions in $x$-direction bounded by `Lx`
-| `calculate_energy`| false | Calculate elastic and plastic energy on each particle
+| `calculate_energy`| false | Calculate elastic and plastic energy on each particle (experimental)
 | `Lx`, `Ly`, `Lz`  | 1.0    | The material sample space used in `sampleParticles(...)`. Not needed when sampling from VDB.
 | `grid_reference_point` | - | Optionally provide a point to be considered in the initial adaptive grid creation, otherwise it only considers the particle domain
 | `elastic_model`        | ElasticModel::Hencky       | Elastic model. Note that Hencky's model must be used when combined with a plastic model. 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ This is a non-exhaustive list of parameters and options (of the `Simulation` cla
 | `use_musl`        | false | Use MUSL instead of USL
 | `use_mibf`        | false | Use Material-Induced Boundary Friction (MIBF), only relevant for certain plasticity models
 | `pbc`             | false | Use periodic boundary conditions in $x$-direction bounded by `Lx`
+| `calculate_energy`| false | Calculate elastic and plastic energy on each particle
 | `Lx`, `Ly`, `Lz`  | 1.0    | The material sample space used in `sampleParticles(...)`. Not needed when sampling from VDB.
 | `grid_reference_point` | - | Optionally provide a point to be considered in the initial adaptive grid creation, otherwise it only considers the particle domain
 | `elastic_model`        | ElasticModel::Hencky       | Elastic model. Note that Hencky's model must be used when combined with a plastic model. 

--- a/src/data_structures.hpp
+++ b/src/data_structures.hpp
@@ -23,6 +23,11 @@ public:
       F.resize(Np); std::fill( F.begin(), F.end(), TM::Identity() );
       Bmat.resize(Np); std::fill( Bmat.begin(), Bmat.end(), TM::Zero() );
       tau.resize(Np); std::fill( tau.begin(), tau.end(), TM::Zero() );
+
+    #ifdef ENERGY
+      Ed.resize(Np); std::fill( Ed.begin(), Ed.end(), 0.0 ); // Ed is energy dissipated through irreversible deformation (plastic or viscoplastic)
+      // Must be computed incrementaly at every time step
+    #endif
   }
 
   std::vector<TV> x;
@@ -41,7 +46,9 @@ public:
   std::vector<TM> Bmat;
   std::vector<TM> tau;
 
-
+#ifdef ENERGY
+  std::vector<T> Ed;
+#endif
 };
 
 class Grid{

--- a/src/data_structures.hpp
+++ b/src/data_structures.hpp
@@ -24,10 +24,7 @@ public:
       Bmat.resize(Np); std::fill( Bmat.begin(), Bmat.end(), TM::Zero() );
       tau.resize(Np); std::fill( tau.begin(), tau.end(), TM::Zero() );
 
-    #ifdef ENERGY
-      Ed.resize(Np); std::fill( Ed.begin(), Ed.end(), 0.0 ); // Ed is energy dissipated through irreversible deformation (plastic or viscoplastic)
-      // Must be computed incrementaly at every time step
-    #endif
+      Ed.resize(Np); std::fill( Ed.begin(), Ed.end(), 0.0 ); 
   }
 
   std::vector<TV> x;
@@ -46,9 +43,7 @@ public:
   std::vector<TM> Bmat;
   std::vector<TM> tau;
 
-#ifdef ENERGY
   std::vector<T> Ed;
-#endif
 };
 
 class Grid{

--- a/src/simulation/plasticity.cpp
+++ b/src/simulation/plasticity.cpp
@@ -40,6 +40,8 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
         if (hencky_deviatoric_norm > 0)
             hencky_deviatoric /= hencky_deviatoric_norm; // normalize the deviatoric vector so it gives a unit vector specifying the deviatoric direction
 
+        T eps_pl_vol_inst = 0; // These are declared here for the purpose of #ENERGY option
+        T eps_pl_dev_inst = 0;
 
         if (plastic_model == PlasticModel::VM){
 
@@ -57,6 +59,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 hencky -= delta_gamma * hencky_deviatoric;
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                 particles.eps_pl_dev[p] += delta_gamma;
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = delta_gamma;
+              #endif
 
             } // end plastic projection
 
@@ -82,8 +88,13 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.delta_gamma[p] = delta_gamma / dt;
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.eps_pl_vol[p] += (p_proj-p_trial)/K;
+              
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                eps_pl_vol_inst = (p_proj-p_trial)/K;
+              #endif 
             }
-            else{ // right of tipe
+            else{ // right of tip
                 T delta_gamma = d_prefac * (hencky_deviatoric_norm - q_yield / e_mu_prefac);
 
                 if (delta_gamma > 0){ // project to yield surface
@@ -93,6 +104,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
                     particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                     particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                  
+                  #ifdef ENERGY
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                  #endif 
                 }
             } // if else side of tip
 
@@ -126,10 +141,14 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.delta_gamma[p] = delta_gamma / dt;
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
 
-                T eps_pl_vol_inst = (p_proj-p_trial)/K;
+                eps_pl_vol_inst = (p_proj-p_trial)/K;
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
                 if (use_pradhana)
                     particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
             }
 
             // right of tip AND inside yield surface, i.e., elastic states
@@ -152,13 +171,17 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     particles.delta_gamma[p]  = delta_gamma / dt;
                     particles.eps_pl_dev[p]  += (1.0/d_prefac) * delta_gamma;
 
-                    T eps_pl_vol_inst = (p_proj-p_trial)/K;
+                    eps_pl_vol_inst = (p_proj-p_trial)/K;
                     particles.eps_pl_vol[p] += eps_pl_vol_inst;
                     if (use_pradhana)
                         particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
 
                     hencky = -p_proj/(K*dim) * TV::Ones();
                     particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
+
+                  #ifdef ENERGY
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                  #endif 
                 }
                 // if right of tip: p_trial becomes p
                 else{
@@ -170,6 +193,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     particles.delta_gamma[p] = delta_gamma / dt;
                     if (use_pradhana)
                         particles.eps_pl_vol_pradhana[p] = 0; // reset volume accumulation
+
+                  #ifdef ENERGY
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                  #endif 
                 }
             } // end plastic projection projection
 
@@ -187,7 +214,7 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             T p_trial = -K * hencky_trace;
             if (p_trial < p_min * exp(-xi * particles.eps_pl_vol[p])){
                 T delta_gamma = q_trial / f_mu_prefac;
-                T eps_pl_vol_inst = -p_trial/K;
+                eps_pl_vol_inst = -p_trial/K;
                 particles.F[p] = svd.matrixU() * svd.matrixV().transpose();
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
@@ -268,6 +295,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.delta_gamma[p] = delta_gamma / dt;
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
             } // end plastic projection projection
 
         } // end VMVisc
@@ -293,7 +324,6 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             // => project to the original tip given by cohesion only (i.e., not the shifted tip)
             if ((p_trial+p_shift) < p_tip){
                 T delta_gamma;
-                T eps_pl_vol_inst, eps_pl_dev_inst;
                 T p_proj = p_tip; // > p_trial
 
                 if (use_duvaut_lions_formulation){ // for simplicity visc_exponent is in this special case assumed to be unity
@@ -319,6 +349,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.delta_gamma[p] = delta_gamma / dt;
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
 
                 if (use_pradhana)
                     particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
@@ -409,6 +443,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.delta_gamma[p] = delta_gamma / dt;
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
             } // end plastic projection
         } // end DPVisc
 
@@ -431,7 +469,7 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             // => project to the original tip given by cohesion only (i.e., not the shifted tip)
             if ((p_trial+p_shift) < p_tip){
                 T delta_gamma     = d_prefac * hencky_deviatoric_norm;
-                T eps_pl_vol_inst = (p_tip-p_trial)/K;
+                eps_pl_vol_inst = (p_tip-p_trial)/K;
                 plastic_count++;
                 hencky = -p_tip/(K*dim) * TV::Ones();
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
@@ -439,6 +477,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.eps_pl_dev[p]          += (1.0/d_prefac) * delta_gamma;
                 particles.eps_pl_vol[p]          += eps_pl_vol_inst;
                 particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
             }
             else{ // if right of shifted tip (incl elastic states)
                 particles.eps_pl_vol_pradhana[p] = 0; // reset pradhana volume accumulation
@@ -471,6 +513,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                 particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.delta_gamma[p] = delta_gamma / dt;
+
+              #ifdef ENERGY
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+              #endif 
 
             } // end plastic projection
 
@@ -519,7 +565,7 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 plastic_count++;
 
                 T ep = p_stress / (K*dim);
-                T eps_pl_vol_inst = hencky_trace + dim * ep;
+                eps_pl_vol_inst = hencky_trace + dim * ep;
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
 
                 if (q_trial > (q_stress + stress_tolerance)) {
@@ -548,6 +594,10 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     T delta_gamma = (q_trial - q_stress) / f_mu_prefac;
                     particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                     particles.delta_gamma[p] = delta_gamma / dt;
+
+                  #ifdef ENERGY
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                  #endif 
                 }
 
                 hencky = q_stress / e_mu_prefac * hencky_deviatoric - ep*TV::Ones();
@@ -672,8 +722,8 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 } // end if MCCVisc
                 ////////////////////////////////////////////////////////////////
 
-                T eps_pl_vol_inst = - b * (p_trial - p_stress) / K;
-                T eps_pl_dev_inst =   b * (q_trial - q_stress) / e_mu_prefac;
+                eps_pl_vol_inst = - b * (p_trial - p_stress) / K;
+                eps_pl_dev_inst =   b * (q_trial - q_stress) / e_mu_prefac;
                 
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
                 particles.eps_pl_dev[p] += eps_pl_dev_inst;
@@ -708,6 +758,13 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
             } // end if perform_rma
         } // end MCC or MCCVisc
+
+      #ifdef ENERGY
+        TV eps_VP = (eps_pl_vol_inst/dim) * TV::Ones() + eps_pl_dev_inst * hencky_deviatoric;
+        TM ld_over_dt =  svd.matrixU() * eps_VP.array().matrix().asDiagonal() * svd.matrixU().transpose(); // ld : velocity gradient of dissipative deformation
+        particles.Ed[p] += particle_volume * doubleDot(particles.tau[p], ld_over_dt);
+        // ld -> dividing by dt ; Ep -> multiplying by dt. Removed dt for efficiency.
+      #endif
 
         // Get new stress
         TM Fe = particles.F[p];

--- a/src/simulation/plasticity.cpp
+++ b/src/simulation/plasticity.cpp
@@ -40,7 +40,7 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
         if (hencky_deviatoric_norm > 0)
             hencky_deviatoric /= hencky_deviatoric_norm; // normalize the deviatoric vector so it gives a unit vector specifying the deviatoric direction
 
-        T eps_pl_vol_inst = 0; // These are declared here for the purpose of #ENERGY option
+        T eps_pl_vol_inst = 0;
         T eps_pl_dev_inst = 0;
 
         if (plastic_model == PlasticModel::VM){
@@ -427,9 +427,6 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.eps_pl_dev[p] += eps_pl_dev_inst;
                 particles.delta_gamma[p] = delta_gamma / dt;
 
-              #ifdef ENERGY
-                
-              #endif 
             } // end plastic projection
         } // end DPVisc
 
@@ -460,10 +457,6 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.eps_pl_dev[p]          += eps_pl_dev_inst;
                 particles.eps_pl_vol[p]          += eps_pl_vol_inst;
                 particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
-
-              #ifdef ENERGY
-                
-              #endif 
             }
             else{ // if right of shifted tip (incl elastic states)
                 particles.eps_pl_vol_pradhana[p] = 0; // reset pradhana volume accumulation

--- a/src/simulation/plasticity.cpp
+++ b/src/simulation/plasticity.cpp
@@ -58,11 +58,8 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                 hencky -= delta_gamma * hencky_deviatoric;
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                particles.eps_pl_dev[p] += delta_gamma;
-
-              #ifdef ENERGY
                 eps_pl_dev_inst = delta_gamma;
-              #endif
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
 
             } // end plastic projection
 
@@ -86,13 +83,12 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                 T delta_gamma = d_prefac * hencky_deviatoric_norm;
                 particles.delta_gamma[p] = delta_gamma / dt;
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
-                particles.eps_pl_vol[p] += (p_proj-p_trial)/K;
-              
-              #ifdef ENERGY
                 eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
                 eps_pl_vol_inst = (p_proj-p_trial)/K;
-              #endif 
+
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
+                particles.eps_pl_vol[p] += eps_pl_vol_inst;
+                              
             }
             else{ // right of tip
                 T delta_gamma = d_prefac * (hencky_deviatoric_norm - q_yield / e_mu_prefac);
@@ -103,11 +99,9 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                     hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
                     particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                    particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
-                  
-                  #ifdef ENERGY
+                    
                     eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-                  #endif 
+                    particles.eps_pl_dev[p] += eps_pl_dev_inst;
                 }
             } // if else side of tip
 
@@ -139,16 +133,13 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                 T delta_gamma = d_prefac * hencky_deviatoric_norm;
                 particles.delta_gamma[p] = delta_gamma / dt;
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
 
                 eps_pl_vol_inst = (p_proj-p_trial)/K;
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
                 if (use_pradhana)
                     particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
-
-              #ifdef ENERGY
-                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-              #endif 
             }
 
             // right of tip AND inside yield surface, i.e., elastic states
@@ -169,7 +160,8 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 if ((p_trial+p_shift) < p_proj){
                     T delta_gamma             = d_prefac * hencky_deviatoric_norm;
                     particles.delta_gamma[p]  = delta_gamma / dt;
-                    particles.eps_pl_dev[p]  += (1.0/d_prefac) * delta_gamma;
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                    particles.eps_pl_dev[p] += eps_pl_dev_inst;
 
                     eps_pl_vol_inst = (p_proj-p_trial)/K;
                     particles.eps_pl_vol[p] += eps_pl_vol_inst;
@@ -178,10 +170,6 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                     hencky = -p_proj/(K*dim) * TV::Ones();
                     particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-
-                  #ifdef ENERGY
-                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-                  #endif 
                 }
                 // if right of tip: p_trial becomes p
                 else{
@@ -189,14 +177,11 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     T delta_gamma = d_prefac * (hencky_deviatoric_norm - q_yield_new / e_mu_prefac);
                     hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
                     particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                    particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                    particles.eps_pl_dev[p] += eps_pl_dev_inst;
                     particles.delta_gamma[p] = delta_gamma / dt;
                     if (use_pradhana)
                         particles.eps_pl_vol_pradhana[p] = 0; // reset volume accumulation
-
-                  #ifdef ENERGY
-                    eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-                  #endif 
                 }
             } // end plastic projection projection
 
@@ -291,14 +276,13 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     } // end N-R iterations
                 } // end if visc_exponent > 1
 
-                hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                hencky -= eps_pl_dev_inst * hencky_deviatoric;
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
                 particles.delta_gamma[p] = delta_gamma / dt;
 
-              #ifdef ENERGY
-                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-              #endif 
             } // end plastic projection projection
 
         } // end VMVisc
@@ -341,18 +325,16 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 else{
                     delta_gamma = d_prefac * hencky_deviatoric_norm;
                     eps_pl_vol_inst = (p_proj-p_trial)/K; // this can be both positive and negative when using Pradhana!
+                    eps_pl_dev_inst = hencky_deviatoric_norm;
                     hencky = -p_proj/(K*dim) * TV::Ones();
                 }
 
                 plastic_count++;
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
                 particles.delta_gamma[p] = delta_gamma / dt;
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
                 particles.eps_pl_vol[p] += eps_pl_vol_inst;
-
-              #ifdef ENERGY
-                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-              #endif 
 
                 if (use_pradhana)
                     particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
@@ -381,7 +363,7 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                         exit = 1;
                     }
                 }
-                else{ // perzyna
+                else{ // exponent not equal to one
 
                     delta_gamma = 0.01 * (q_trial - q_yield) / f_mu_prefac; // initial guess
 
@@ -439,13 +421,14 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                         particles.muI[p] = ((q_trial - f_mu_prefac * delta_gamma) - q_cohesion) / (p_trial + p_shift);
                 }
 
-                hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
+                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                hencky -= eps_pl_dev_inst * hencky_deviatoric;
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
                 particles.delta_gamma[p] = delta_gamma / dt;
 
               #ifdef ENERGY
-                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                
               #endif 
             } // end plastic projection
         } // end DPVisc
@@ -468,18 +451,18 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             // if left of shifted tip,
             // => project to the original tip given by cohesion only (i.e., not the shifted tip)
             if ((p_trial+p_shift) < p_tip){
-                T delta_gamma     = d_prefac * hencky_deviatoric_norm;
-                eps_pl_vol_inst = (p_tip-p_trial)/K;
+                eps_pl_vol_inst = (p_tip-p_trial) / K;
+                eps_pl_dev_inst = hencky_deviatoric_norm;
                 plastic_count++;
                 hencky = -p_tip/(K*dim) * TV::Ones();
                 particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                particles.delta_gamma[p]          = delta_gamma;               // NB!
-                particles.eps_pl_dev[p]          += (1.0/d_prefac) * delta_gamma;
+                particles.delta_gamma[p]          = d_prefac * eps_pl_dev_inst / dt;
+                particles.eps_pl_dev[p]          += eps_pl_dev_inst;
                 particles.eps_pl_vol[p]          += eps_pl_vol_inst;
                 particles.eps_pl_vol_pradhana[p] += eps_pl_vol_inst; // can be negative!
 
               #ifdef ENERGY
-                eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
+                
               #endif 
             }
             else{ // if right of shifted tip (incl elastic states)
@@ -508,16 +491,14 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 particles.viscosity[p] = (mu_i - mu_1) * p_special / delta_gamma;
 
                 delta_gamma *= dt; // this is the actual delta_gamma
-
-                hencky -= (1.0/d_prefac) * delta_gamma * hencky_deviatoric;
-                particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
-                particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
                 particles.delta_gamma[p] = delta_gamma / dt;
 
-              #ifdef ENERGY
                 eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-              #endif 
+                particles.eps_pl_dev[p] += eps_pl_dev_inst;
 
+                hencky -= eps_pl_dev_inst * hencky_deviatoric;
+                particles.F[p] = svd.matrixU() * hencky.array().exp().matrix().asDiagonal() * svd.matrixV().transpose();
+                
             } // end plastic projection
 
         } // end DPMui
@@ -592,12 +573,9 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                     particles.viscosity[p] = (mu_i - mu_1) * std::sqrt((p_c-p_stress)*p_special) / gamma_dot_S;
 
                     T delta_gamma = (q_trial - q_stress) / f_mu_prefac;
-                    particles.eps_pl_dev[p] += (1.0/d_prefac) * delta_gamma;
-                    particles.delta_gamma[p] = delta_gamma / dt;
-
-                  #ifdef ENERGY
                     eps_pl_dev_inst = (1.0/d_prefac) * delta_gamma;
-                  #endif 
+                    particles.eps_pl_dev[p] += eps_pl_dev_inst;
+                    particles.delta_gamma[p] = delta_gamma / dt;
                 }
 
                 hencky = q_stress / e_mu_prefac * hencky_deviatoric - ep*TV::Ones();
@@ -759,12 +737,6 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             } // end if perform_rma
         } // end MCC or MCCVisc
 
-      #ifdef ENERGY
-        TV eps_VP = (eps_pl_vol_inst/dim) * TV::Ones() + eps_pl_dev_inst * hencky_deviatoric;
-        TM ld_over_dt =  svd.matrixU() * eps_VP.array().matrix().asDiagonal() * svd.matrixU().transpose(); // ld : velocity gradient of dissipative deformation
-        particles.Ed[p] += particle_volume * doubleDot(particles.tau[p], ld_over_dt);
-        // ld -> dividing by dt ; Ep -> multiplying by dt. Removed dt for efficiency.
-      #endif
 
         // Get new stress
         TM Fe = particles.F[p];
@@ -773,13 +745,20 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
             dPsidF = mu * (Fe - Fe.transpose().inverse()) + lambda * std::log(Fe.determinant()) * Fe.transpose().inverse();
             particles.tau[p] = dPsidF * Fe.transpose();
         }
-        else if (elastic_model == ElasticModel::Hencky){ // St Venant Kirchhoff with Hencky strain
+        else if (elastic_model == ElasticModel::Hencky){
             T e_trace = hencky.sum();
             TV Kirchhoff_principal = lambda*e_trace*TV::Ones() + T(2.)*mu*hencky;
             particles.tau[p] = svd.matrixU() * Kirchhoff_principal.array().matrix().asDiagonal() * svd.matrixU().transpose();
         }
         else{
             debug("You specified an unvalid ELASTIC model!");
+        }
+
+
+        if (calculate_energy){
+            TV eps_pl_inst = (eps_pl_vol_inst/dim) * TV::Ones() + eps_pl_dev_inst * hencky_deviatoric;
+            TM eps_pl_inst_matrix =  svd.matrixU() * eps_pl_inst.array().matrix().asDiagonal() * svd.matrixU().transpose(); // = (plastic velocity gradient) * dt
+            particles.Ed[p] += particle_volume * doubleDot(particles.tau[p], eps_pl_inst_matrix);
         }
 
     } // end plastic_model type

--- a/src/simulation/plasticity.cpp
+++ b/src/simulation/plasticity.cpp
@@ -483,8 +483,14 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
                 T fac_b = p_trial*(mu_2-mu_1) + f_mu_prefac*dt*fac_Q*std::sqrt(p_special) - (q_trial-q_yield);
                 T fac_c = -(q_trial-q_yield) * fac_Q * std::sqrt(p_special); // always negative 
 
-                // this is gamma_dot:
-                T delta_gamma = (-fac_b + std::sqrt(fac_b*fac_b - 4*fac_a*fac_c) ) / (2*fac_a); // always if because a>0 and c<0
+                T delta_gamma; // this is gamma_dot: always positive if because a>0 and c<0
+                T sqrtdet = std::sqrt(fac_b*fac_b - 4*fac_a*fac_c);
+                if (fac_b > 0){
+                    delta_gamma = 2*fac_c / (-fac_b - sqrtdet);
+                }
+                else {
+                    delta_gamma = (-fac_b + sqrtdet) / (2 * fac_a);
+                }
 
                 T mu_i = mu_1 + (mu_2 - mu_1) / (fac_Q * std::sqrt(p_special) / delta_gamma + 1.0);
                 particles.muI[p]       = mu_i;
@@ -564,7 +570,14 @@ void Simulation::plasticity(unsigned int p, unsigned int & plastic_count, TM & F
 
                     T fac_c = -(q_trial-q_stress) * fac_Q * std::sqrt(p_special); // always negative
 
-                    T gamma_dot_S = (-fac_b + std::sqrt(fac_b*fac_b - 4*fac_a*fac_c) ) / (2*fac_a); // always positive because a>0 and c<0
+                    T gamma_dot_S; // always positive because a>0 and c<0
+                    T sqrtdet = std::sqrt(fac_b*fac_b - 4*fac_a*fac_c);
+                    if (fac_b > 0){
+                        gamma_dot_S = 2*fac_c / (-fac_b - sqrtdet);
+                    }
+                    else {
+                        gamma_dot_S = (-fac_b + sqrtdet) / (2 * fac_a);
+                    }
 
                     q_stress = std::max(q_stress, q_trial - f_mu_prefac * dt * gamma_dot_S); // always smaller than q_trial
             

--- a/src/simulation/save_data.cpp
+++ b/src/simulation/save_data.cpp
@@ -9,13 +9,10 @@ void Simulation::saveParticleData(std::string extra){
     std::vector<T> pressure_vec(Np);
     std::vector<T> devstress_vec(Np);
     std::vector<T> Je_vec(Np);
-
-#ifdef ENERGY
-    std::vector<T> Ek(Np); // Kinetic energy
-    std::vector<T> Eg(Np); // Gravitational potential energy
-    std::vector<T> Ee(Np); // Elastic energy
-    // Ed is energy dissipated through irreversible deformation (plastic or viscoplastic)
-#endif
+    std::vector<T> Ee;
+    if (calculate_energy){
+        Ee.resize(Np);
+    }
 
     #pragma omp parallel for num_threads(n_threads)
     for(int p = 0; p < Np; p++){
@@ -42,32 +39,26 @@ void Simulation::saveParticleData(std::string extra){
         devstress_vec[p] = devstress;
         Je_vec[p] = Je;
 
-    #ifdef ENERGY
-      #ifdef THREEDIM
-        Ek[p] = 0.5 * particle_mass * ( particles.v[p][0]*particles.v[p][0] + particles.v[p][1]*particles.v[p][1] + particles.v[p][2]*particles.v[p][2]);
-      #else
-        Ek[p] = 0.5 * particle_mass * ( particles.v[p][0]*particles.v[p][0] + particles.v[p][1]*particles.v[p][1] );
-      #endif
-        Eg[p] = particle_mass * 9.81 * particles.x[p][1];
-        
-        // Elastic energy computed from elastic energy density function
-        T J = Je * std::exp( particles.eps_pl_vol[p] );
-        if (elastic_model == ElasticModel::NeoHookean){
-            T log_J = std::log(J);
-            Ee[p] = particle_volume * ( 0.5 * lambda * log_J*log_J + 0.5 * mu * (selfDoubleDot(Fe) - dim - 2*log_J ) );
-        }
-        else if (elastic_model == ElasticModel::Hencky){ // St Venant Kirchhoff with Hencky strain
-            Eigen::JacobiSVD<TM> svd(Fe, Eigen::ComputeFullU | Eigen::ComputeFullV);
-            TV hencky_singular = svd.singularValues().array().abs().max(1e-4).log();
-            T  hencky_trace = hencky_singular.sum();
-            TM hencky = svd.matrixU() * hencky_singular.matrix().asDiagonal() * svd.matrixV().transpose();
-            Ee[p] = particle_volume * ( 0.5 * lambda * hencky_trace * hencky_trace + mu * (hencky*hencky).trace() );
-        }
-        else{
-            debug("You specified an unvalid ELASTIC model!");
-        }
-    #endif
-    }
+        if (calculate_energy){
+            // Elastic energy computed from elastic energy density function
+            T J = Je * std::exp( particles.eps_pl_vol[p] );
+            if (elastic_model == ElasticModel::NeoHookean){
+                T log_J = std::log(J);
+                Ee[p] = particle_volume * ( 0.5 * lambda * log_J*log_J + 0.5 * mu * ((Fe.transpose()*Fe).trace() - dim - 2*log_J ) );
+            }
+            else if (elastic_model == ElasticModel::Hencky){ 
+                Eigen::JacobiSVD<TM> svd(Fe, Eigen::ComputeFullU | Eigen::ComputeFullV);
+                TV hencky_singular = svd.singularValues().array().abs().max(1e-4).log();
+                T  hencky_trace = hencky_singular.sum();
+                TM hencky = svd.matrixU() * hencky_singular.matrix().asDiagonal() * svd.matrixV().transpose();
+                Ee[p] = particle_volume * ( 0.5 * lambda * hencky_trace * hencky_trace + mu * (hencky*hencky).trace() );
+            }
+            else{
+                debug("You specified an unvalid ELASTIC model!");
+            }
+        } // end calculate_energy
+
+    } // end loop over p
 
 
     std::string filename = directory + sim_name + "/particles_f" + extra + std::to_string(frame) + ".ply";
@@ -140,43 +131,25 @@ void Simulation::saveParticleData(std::string extra){
         tinyply::Type::INVALID,
         0);
 
-  #ifdef ENERGY
-    file.add_properties_to_element(
-        "vertex",
-        { "Ek" },
-        type,
-        Ek.size(),
-        reinterpret_cast<uint8_t*>(Ek.data()),
-        tinyply::Type::INVALID,
-        0);  
+    if (calculate_energy){
+        file.add_properties_to_element(
+            "vertex",
+            { "Ee" },
+            type,
+            Ee.size(),
+            reinterpret_cast<uint8_t*>(Ee.data()),
+            tinyply::Type::INVALID,
+            0);  
 
-    file.add_properties_to_element(
-        "vertex",
-        { "Eg" },
-        type,
-        Eg.size(),
-        reinterpret_cast<uint8_t*>(Eg.data()),
-        tinyply::Type::INVALID,
-        0);  
-
-    file.add_properties_to_element(
-        "vertex",
-        { "Ee" },
-        type,
-        Ee.size(),
-        reinterpret_cast<uint8_t*>(Ee.data()),
-        tinyply::Type::INVALID,
-        0);  
-
-    file.add_properties_to_element(
-        "vertex",
-        { "Ed" },
-        type,
-        particles.Ed.size(),
-        reinterpret_cast<uint8_t*>(particles.Ed.data()),
-        tinyply::Type::INVALID,
-        0);
-  #endif
+        file.add_properties_to_element(
+            "vertex",
+            { "Ed" },
+            type,
+            particles.Ed.size(),
+            reinterpret_cast<uint8_t*>(particles.Ed.data()),
+            tinyply::Type::INVALID,
+            0);
+    }
 
     if (plastic_model != PlasticModel::NoPlasticity){
 

--- a/src/simulation/save_data.cpp
+++ b/src/simulation/save_data.cpp
@@ -10,6 +10,13 @@ void Simulation::saveParticleData(std::string extra){
     std::vector<T> devstress_vec(Np);
     std::vector<T> Je_vec(Np);
 
+#ifdef ENERGY
+    std::vector<T> Ek(Np); // Kinetic energy
+    std::vector<T> Eg(Np); // Gravitational potential energy
+    std::vector<T> Ee(Np); // Elastic energy
+    // Ed is energy dissipated through irreversible deformation (plastic or viscoplastic)
+#endif
+
     #pragma omp parallel for num_threads(n_threads)
     for(int p = 0; p < Np; p++){
 
@@ -34,6 +41,32 @@ void Simulation::saveParticleData(std::string extra){
         pressure_vec[p] = pressure;
         devstress_vec[p] = devstress;
         Je_vec[p] = Je;
+
+    #ifdef ENERGY
+      #ifdef THREEDIM
+        Ek[p] = 0.5 * particle_mass * ( particles.v[p][0]*particles.v[p][0] + particles.v[p][1]*particles.v[p][1] + particles.v[p][2]*particles.v[p][2]);
+      #else
+        Ek[p] = 0.5 * particle_mass * ( particles.v[p][0]*particles.v[p][0] + particles.v[p][1]*particles.v[p][1] );
+      #endif
+        Eg[p] = particle_mass * 9.81 * particles.x[p][1];
+        
+        // Elastic energy computed from elastic energy density function
+        T J = Je * std::exp( particles.eps_pl_vol[p] );
+        if (elastic_model == ElasticModel::NeoHookean){
+            T log_J = std::log(J);
+            Ee[p] = particle_volume * ( 0.5 * lambda * log_J*log_J + 0.5 * mu * (selfDoubleDot(Fe) - dim - 2*log_J ) );
+        }
+        else if (elastic_model == ElasticModel::Hencky){ // St Venant Kirchhoff with Hencky strain
+            Eigen::JacobiSVD<TM> svd(Fe, Eigen::ComputeFullU | Eigen::ComputeFullV);
+            TV hencky_singular = svd.singularValues().array().abs().max(1e-4).log();
+            T  hencky_trace = hencky_singular.sum();
+            TM hencky = svd.matrixU() * hencky_singular.matrix().asDiagonal() * svd.matrixV().transpose();
+            Ee[p] = particle_volume * ( 0.5 * lambda * hencky_trace * hencky_trace + mu * (hencky*hencky).trace() );
+        }
+        else{
+            debug("You specified an unvalid ELASTIC model!");
+        }
+    #endif
     }
 
 
@@ -106,6 +139,44 @@ void Simulation::saveParticleData(std::string extra){
         reinterpret_cast<uint8_t*>(Je_vec.data()),
         tinyply::Type::INVALID,
         0);
+
+  #ifdef ENERGY
+    file.add_properties_to_element(
+        "vertex",
+        { "Ek" },
+        type,
+        Ek.size(),
+        reinterpret_cast<uint8_t*>(Ek.data()),
+        tinyply::Type::INVALID,
+        0);  
+
+    file.add_properties_to_element(
+        "vertex",
+        { "Eg" },
+        type,
+        Eg.size(),
+        reinterpret_cast<uint8_t*>(Eg.data()),
+        tinyply::Type::INVALID,
+        0);  
+
+    file.add_properties_to_element(
+        "vertex",
+        { "Ee" },
+        type,
+        Ee.size(),
+        reinterpret_cast<uint8_t*>(Ee.data()),
+        tinyply::Type::INVALID,
+        0);  
+
+    file.add_properties_to_element(
+        "vertex",
+        { "Ed" },
+        type,
+        particles.Ed.size(),
+        reinterpret_cast<uint8_t*>(particles.Ed.data()),
+        tinyply::Type::INVALID,
+        0);
+  #endif
 
     if (plastic_model != PlasticModel::NoPlasticity){
 

--- a/src/simulation/simulation.hpp
+++ b/src/simulation/simulation.hpp
@@ -45,6 +45,7 @@ public:
   bool save_grid = false;
   bool use_mibf = false;
   bool use_musl = false;
+  bool calculate_energy = false;
 
   TV grid_reference_point = 2e10 * TV::Ones();
   TV gravity = TV::Zero();
@@ -227,6 +228,7 @@ private:
 #endif
 }; // end Simulation class
 
+// These functions are not used anymore (now done in plasticity.cpp):
 inline TM Simulation::NeoHookeanPiola(TM & Fe){
     return mu * (Fe - Fe.transpose().inverse()) + lambda * std::log(Fe.determinant()) * Fe.transpose().inverse();
 } // end NeoHookeanPiola

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -20,7 +20,6 @@ typedef double T; // float or double
 // #define THREEDIM // Uncomment for 2D
 #define SPLINEDEG 2 // Quadratic B-spline
 // #define WARNINGS // Write more debug info to screen
-#define ENERGY // Uncomment to perform energy balance
 ///////////////////////////////////////////////////
 
 
@@ -106,8 +105,6 @@ inline T selfDoubleDot(TM& A){
     return out;
 }
 
-#ifdef ENERGY  // Added double dot operation for computation of Ed
-// Maybe this function can be added by default for simplicity
 inline T doubleDot(TM& A, TM& B){
 
     #ifdef THREEDIM
@@ -121,7 +118,6 @@ inline T doubleDot(TM& A, TM& B){
 
     return out;
 }
-#endif
 
 #if SPLINEDEG == 3
 

--- a/src/tools.hpp
+++ b/src/tools.hpp
@@ -20,6 +20,7 @@ typedef double T; // float or double
 // #define THREEDIM // Uncomment for 2D
 #define SPLINEDEG 2 // Quadratic B-spline
 // #define WARNINGS // Write more debug info to screen
+#define ENERGY // Uncomment to perform energy balance
 ///////////////////////////////////////////////////
 
 
@@ -104,6 +105,23 @@ inline T selfDoubleDot(TM& A){
 
     return out;
 }
+
+#ifdef ENERGY  // Added double dot operation for computation of Ed
+// Maybe this function can be added by default for simplicity
+inline T doubleDot(TM& A, TM& B){
+
+    #ifdef THREEDIM
+    T out = A(0,0)*B(0,0) + A(0,1)*B(0,1) + A(0,2)*B(0,2)
+          + A(1,0)*B(1,0) + A(1,1)*B(1,1) + A(1,2)*B(1,2)
+          + A(2,0)*B(2,0) + A(2,1)*B(2,1) + A(2,2)*B(2,2);
+    #else
+    T out = A(0,0)*B(0,0) + A(0,1)*B(0,1)
+          + A(1,0)*B(1,0) + A(1,1)*B(1,1);
+    #endif
+
+    return out;
+}
+#endif
 
 #if SPLINEDEG == 3
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-find_package (Eigen3 REQUIRED NO_MODULE)
+find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(OpenMP REQUIRED)
 
 


### PR DESCRIPTION
Hello there,

I implemented the computation of energies : kinetic, gravitational, elastic and visco(plastic) dissipation. This allows to perform energy balances of simulation and evaluate total energy loss due to numerical dissipation. I believe it will be a great addition as evaluating and reducing numerical dissipation is a big issue in MPM and often a source of critic.

Since this addition leads to more computations (incremental addition of dissipative energy) and heavier output files (storage of 4 energies in particles_*.hpp), it  is implemented as an option : ```#define ENERGY``` in `tools.hpp`.

They were some adjustments I had to make to `plasticity.cpp` in order to get `eps_pl_vol_inst` and `eps_pl_dev_inst` for every plastic model.

Let me know what you think,

Cheers
Alexandre.