### PR TITLE
move objects only after gravity applied in case of gravity special

### DIFF
--- a/src/simulation/simulation.cpp
+++ b/src/simulation/simulation.cpp
@@ -325,14 +325,15 @@ void Simulation::advanceStep(){
 
 
 void Simulation::moveObjects(){
-    for (auto& obj : plates) {
-        obj->move(dt, frame_dt, time);
-    }
-
-    for (auto& obj : objects) {
-        obj->move(time);
-    }
-}
+    if ( !gravity_special || (gravity_special && time >= gravity_time) ){
+        for (auto& obj : plates) {
+            obj->move(dt, frame_dt, time);
+        }
+        for (auto& obj : objects) {
+            obj->move(time);
+        }
+    } // endif
+} // end moveObjects
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi there,

I added an if statement to the moveObjects function in simulation.cpp. Now, when using gravity_special, the objects start moving only after the gravity is fully applied. I think it is preferred in most (if not all) configurations.

Let me know if you disagree.

Cheers,
AP.